### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/cogi-java-parent/pom.xml
+++ b/cogi-java-parent/pom.xml
@@ -21,7 +21,7 @@
         <commons.lang3.version>3.4</commons.lang3.version>
         <commons.beanutils.version>1.9.2</commons.beanutils.version>
         <commons.io.version>2.4</commons.io.version>
-        <commons-collections.version>3.2.1</commons-collections.version>
+        <commons-collections.version>3.2.2</commons-collections.version>
         <junit.version>4.12</junit.version>
         <com.fasterxml.jackson.core.version>2.6.0</com.fasterxml.jackson.core.version>
         <ch.qos.logback.version>1.1.3</ch.qos.logback.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
